### PR TITLE
Make it possible to compile module dynamically

### DIFF
--- a/config
+++ b/config
@@ -1,3 +1,16 @@
 ngx_addon_name=ngx_http_knock_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_knock_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_knock_module.c"
+
+KNOCK_SRCS="$ngx_addon_dir/ngx_http_knock_module.c"
+
+if test -n "$ngx_module_link"; then
+  ngx_module_type=HTTP
+  ngx_module_name="ngx_http_knock_module"
+  ngx_module_srcs="$KNOCK_SRCS"
+  ngx_module_deps=""
+  ngx_module_incs=""
+  ngx_module_libs=""
+  . auto/module
+else
+  HTTP_MODULES="$HTTP_MODULES ngx_http_knock_module"
+  NGX_ADDON_SRCS="$NGX_ADDON_SRCS $KNOCK_SRCS"
+fi


### PR DESCRIPTION
I changed config file to make it work when compiled dynamically (--add-dynamic-module)
Tested on 1.13.4
https://www.nginx.com/blog/nginx-dynamic-modules-how-they-work/#conversion

This allowed for creating package for it on AUR https://aur.archlinux.org/packages/nginx-mod-http-knock/ (currently package assumes that this patch is merged)